### PR TITLE
Fix highlighting of string escape sequences

### DIFF
--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -46,8 +46,8 @@ syn keyword dartType        bool double enum int String StringBuffer void
 syn keyword dartTodo        contained TODO FIXME XXX
 
 
-syn match  dartEscape       contained "\\\([4-9]\d\|[0-3]\d\d\|[\"\\'ntbrf]\|u\x\{4\}\)"
 syn match  dartSpecialError contained "\\."
+syn match  dartEscape       contained "\\\([4-9]\d\|[0-3]\d\d\|[\"\\'ntbrf]\|u\x\{4\}\)"
 syn match  dartStrInterpol  contained "\${[\x, _]*\}"
 
 syn region dartDQString     start=+"+ end=+"+ end=+$+ contains=dartEscape,dartStrInterpol,dartSpecialError,@Spell


### PR DESCRIPTION
The leading `\` and next character of all escape sequences was being
highlighted as an error.