### PR TITLE
Fix number highlighting

### DIFF
--- a/syntax/dart.vim
+++ b/syntax/dart.vim
@@ -72,6 +72,7 @@ hi def link dartIdentifier      Identifier
 hi def link dartLabel           Label
 hi def link dartLineComment     Comment
 hi def link dartNull            Keyword
+hi def link dartNumber          Number
 hi def link dartOperator        Operator
 hi def link dartRepeat          Repeat
 hi def link dartReserved        Keyword


### PR DESCRIPTION
The number syntax group was not assigned to any highlight group.